### PR TITLE
Match the test class name to the test file name

### DIFF
--- a/test/arelastic/queries/match_none_test.rb
+++ b/test/arelastic/queries/match_none_test.rb
@@ -1,6 +1,6 @@
 require 'helper'
 
-class Arelastic::Queries::MatchAllTest < Minitest::Test
+class Arelastic::Queries::MatchNoneTest < Minitest::Test
   def test_as_elastic
     match_all = Arelastic::Queries::MatchNone.new
 


### PR DESCRIPTION
Fixes the following warning when running the tests:

```
/home/travis/build/matthuhiggins/arelastic/test/arelastic/queries/match_none_test.rb:4: warning: method redefined; discarding old test_as_elastic
/home/travis/build/matthuhiggins/arelastic/test/arelastic/queries/match_all_test.rb:4: warning: previous definition of test_as_elastic was here
```