### PR TITLE
Percolate query supports multiple documents

### DIFF
--- a/lib/arelastic/queries/percolate.rb
+++ b/lib/arelastic/queries/percolate.rb
@@ -11,10 +11,14 @@ module Arelastic
       def as_elastic
         {
           "percolate" => {
-            "field"     => field,
-            "document"  => document
+            "field"                  => field,
+            document_parameter_name  => document
           }.merge(options)
         }
+      end
+
+      def document_parameter_name
+        document.is_a?(Array) ? "documents" : "document"
       end
     end
   end

--- a/test/arelastic/queries/percolate_test.rb
+++ b/test/arelastic/queries/percolate_test.rb
@@ -12,6 +12,20 @@ class Arelastic::Queries::PercolateTest < Minitest::Test
     assert_equal expected, percolate.as_elastic
   end
 
+  def test_as_elastic_with_multiple_documents
+    percolate = Arelastic::Queries::Percolate.new(
+      "query",
+      [{ "color" => "red" }, { "color" => "blue" }]
+    )
+    expected = {
+      "percolate" => {
+        "field" => "query",
+        "documents" => [{ "color" => "red" }, { "color" => "blue" }]
+      }
+    }
+    assert_equal expected, percolate.as_elastic
+  end
+
   def test_as_elastic_with_options
     percolate = Arelastic::Queries::Percolate.new("query", {"color" => "red"}, {"document_type" => "widget"})
     expected = {


### PR DESCRIPTION
**Problem**

ElasticSearch percolate queries support multiple documents ([reference](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html#_percolating_multiple_documents))

**Solution**

When given multiple documents, automatically build the right query.

