### PR TITLE
Rename Arelastic::Builders::Query to Arelastic::Builders::Query

### DIFF
--- a/lib/arelastic.rb
+++ b/lib/arelastic.rb
@@ -7,3 +7,11 @@ require 'arelastic/searches'
 require 'arelastic/sorts'
 
 require 'arelastic/builders'
+
+module Arelastic
+  class << self
+    def queries
+      Arelastic::Builders::Search.query
+    end
+  end
+end

--- a/lib/arelastic.rb
+++ b/lib/arelastic.rb
@@ -11,7 +11,7 @@ require 'arelastic/builders'
 module Arelastic
   class << self
     def queries
-      Arelastic::Builders::Search.query
+      Arelastic::Builders::Queries
     end
   end
 end

--- a/lib/arelastic/builders.rb
+++ b/lib/arelastic/builders.rb
@@ -1,6 +1,6 @@
 require 'arelastic/builders/aggregation'
 require 'arelastic/builders/filter'
 require 'arelastic/builders/mapping'
-require 'arelastic/builders/query'
+require 'arelastic/builders/queries'
 require 'arelastic/builders/search'
 require 'arelastic/builders/sort'

--- a/lib/arelastic/builders/queries.rb
+++ b/lib/arelastic/builders/queries.rb
@@ -1,6 +1,6 @@
 module Arelastic
   module Builders
-    class Query < Struct.new :name
+    class Queries < Struct.new :name
       MACROS_TO_ARELASTIC = {
         bool:                Arelastic::Queries::Bool,
         constant_score:      Arelastic::Queries::ConstantScore,

--- a/lib/arelastic/builders/search.rb
+++ b/lib/arelastic/builders/search.rb
@@ -14,8 +14,8 @@ module Arelastic
           Arelastic::Builders::Aggregation
         end
 
-        def query
-          Arelastic::Builders::Query
+        def queries
+          Arelastic::Builders::Queries
         end
 
         def sort

--- a/test/arelastic/builders/queries_test.rb
+++ b/test/arelastic/builders/queries_test.rb
@@ -1,15 +1,15 @@
 require 'helper'
 
-class Arelastic::Builders::QueryTest < Minitest::Test
+class Arelastic::Builders::QueriesTest < Minitest::Test
   def test_constant_score
-    query = Arelastic::Builders::Query.constant_score({"foo" => "bar"})
+    query = Arelastic::Builders::Queries.constant_score({"foo" => "bar"})
     expected = {"constant_score" => {"foo" => "bar"}}
 
     assert_equal expected, query.as_elastic
   end
 
   def test_bool
-    query = Arelastic::Builders::Query.bool(
+    query = Arelastic::Builders::Queries.bool(
       must: {"query_string" => "foo"},
       filter: {"term" => "bar"}
     )
@@ -19,39 +19,39 @@ class Arelastic::Builders::QueryTest < Minitest::Test
   end
 
   def test_match_all
-    query = Arelastic::Builders::Query.match_all
+    query = Arelastic::Builders::Queries.match_all
     expected = {"match_all" => {}}
 
     assert_equal expected, query.as_elastic
   end
 
   def test_multi_match
-    Arelastic::Builders::Query.multi_match 'blue', ['color', 'description']
+    Arelastic::Builders::Queries.multi_match 'blue', ['color', 'description']
   end
 
   def test_field
-    query = Arelastic::Builders::Query['user'].field 'kimchy'
+    query = Arelastic::Builders::Queries['user'].field 'kimchy'
     expected = { "field" => { "user" => "kimchy" } }
 
     assert_equal expected, query.as_elastic
   end
 
   def test_term
-    query = Arelastic::Builders::Query['user'].term 'kimchy'
+    query = Arelastic::Builders::Queries['user'].term 'kimchy'
     expected = {"term" => { "user" => "kimchy" }}
 
     assert_equal expected, query.as_elastic
   end
 
   def test_terms
-    query = Arelastic::Builders::Query['tags'].terms ['blue', 'pill']
+    query = Arelastic::Builders::Queries['tags'].terms ['blue', 'pill']
     expected = {"terms" => { "tags" => ["blue", "pill"] }}
 
     assert_equal expected, query.as_elastic
   end
 
   def test_match
-    query = Arelastic::Builders::Query['message'].match "hello"
+    query = Arelastic::Builders::Queries['message'].match "hello"
     expected = {"match" => { "message" => "hello" }}
 
     assert_equal expected, query.as_elastic

--- a/test/arelastic/builders/search_test.rb
+++ b/test/arelastic/builders/search_test.rb
@@ -14,7 +14,7 @@ class Arelastic::Builders::SearchTest < Minitest::Test
   end
 
   def test_query
-    assert_equal Arelastic::Builders::Query, Arelastic::Builders::Search.query
+    assert_equal Arelastic::Builders::Queries, Arelastic::Builders::Search.queries
   end
 
   def test_sort

--- a/test/arelastic_test.rb
+++ b/test/arelastic_test.rb
@@ -1,0 +1,7 @@
+require 'helper'
+
+class ArelasticTest < Minitest::Test
+  def test_queries
+    assert_equal Arelastic::Builders::Queries, Arelastic.queries
+  end
+end


### PR DESCRIPTION
Using the method name `query` to access the queries builder while using `ElasticRecord` is awkward as `query` is a search method on `ElasticRecord::Relation`. This changes the builder to use the method name `queries` to:

1. Help prevent collisions with the method `query` on `ElasticRecord`.
2. Make it more obvious that `queries` is used to select/build one of many query types.

**Changes**
* Rename `Arelastic::Builders::Query` to `Arelastic::Builders::Query`
* Add `Arelastic.queries` method to make access to query builder easier