### PR TITLE
Add README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Arelastic::Nodes::HashGroup.new(search).as_elastic
 # => {"query"=>{"term"=>{"name"=>"Fun"}}, "size"=>20, "from"=>20, "sort"=>[{"price"=>"asc"}]}
 ```
 
-Some helpful Arel builders can be found [here](/blob/master/lib/arelastic/builders/filter.rb.)
+Some helpful Arel builders can be found [here](/lib/arelastic/builders/filter.rb).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 [![Build Status](https://travis-ci.org/matthuhiggins/arelastic.svg?branch=master)](https://travis-ci.org/matthuhiggins/arelastic) [![Code Climate](https://codeclimate.com/github/matthuhiggins/arelastic/badges/gpa.svg)](https://codeclimate.com/github/matthuhiggins/arelastic)
+# Arelastic
+
+Arelastic is a Elasticsearch AST manager for Ruby. It simplifies the generation complex of Elasticsearch queries
+
+It is intended to be a framework framework; that is, you can build your own ORM with it.
+
+One example is [Elastic Record](https://github.com/data-axle/elastic_record)
+
+## Usage
+
+### Search
+```ruby
+search = Arelastic::Builders::Search['name']
+
+# Name equals red
+search.eq('red').as_elastic
+# => {"term"=>{"name"=>"red"}}
+
+# Negation
+search.eq("red").negate.as_elastic
+# => {"bool"=>{"must_not"=>{"term"=>{:name=>"red"}}}}
+```
+
+### Limit & Offset
+```ruby
+# Limit
+Arelastic::Searches::Size.new(20).as_elastic
+# => {"size"=>20}
+
+# Offset
+Arelastic::Searches::From.new(20).as_elastic
+# => {"from"=>20}
+```
+
+### Ordering
+```ruby
+sort_field = Arelastic::Sorts::Field.new('price' => 'asc')
+sort_field.as_elastic
+#  => {'price' => 'asc'}
+
+sort = Arelastic::Searches::Sort.new([sort_field])
+sort.as_elastic
+# => {"sort"=>[{"price"=>"asc"}]}
+```
+
+### Putting It All Together
+```ruby
+search = [
+ Arelastic::Searches::Query.new(Arelastic::Builders::Search['name'].eq('Fun')),
+ Arelastic::Searches::Size.new(20),
+ Arelastic::Searches::From.new(20),
+ Arelastic::Searches::Sort.new([Arelastic::Sorts::Field.new('price' => 'asc')])
+]
+Arelastic::Nodes::HashGroup.new(search).as_elastic
+# => {"query"=>{"term"=>{"name"=>"Fun"}}, "size"=>20, "from"=>20, "sort"=>[{"price"=>"asc"}]}
+```
+
+Some helpful Arel builders can be found [here](/blob/master/lib/arelastic/builders/filter.rb.)


### PR DESCRIPTION
The README didn't have any content about how this repo could be used.
This adds basic examples for query with a limit, offset, and order.