### PR TITLE
Support for "bucket_sort" and "bucket_selector" pipeline aggregations

### DIFF
--- a/lib/arelastic/aggregations.rb
+++ b/lib/arelastic/aggregations.rb
@@ -1,6 +1,7 @@
 require 'arelastic/aggregations/aggregation'
 require 'arelastic/aggregations/bucket'
 
+require 'arelastic/aggregations/bucket_sort'
 require 'arelastic/aggregations/cardinality'
 require 'arelastic/aggregations/date_histogram'
 require 'arelastic/aggregations/filter'

--- a/lib/arelastic/aggregations.rb
+++ b/lib/arelastic/aggregations.rb
@@ -2,6 +2,7 @@ require 'arelastic/aggregations/aggregation'
 require 'arelastic/aggregations/bucket'
 
 require 'arelastic/aggregations/bucket_sort'
+require 'arelastic/aggregations/bucket_selector'
 require 'arelastic/aggregations/cardinality'
 require 'arelastic/aggregations/date_histogram'
 require 'arelastic/aggregations/filter'

--- a/lib/arelastic/aggregations/bucket_selector.rb
+++ b/lib/arelastic/aggregations/bucket_selector.rb
@@ -1,0 +1,23 @@
+module Arelastic
+  module Aggregations
+    class BucketSelector < Arelastic::Aggregations::Aggregation
+      attr_accessor :script_params, :script
+
+      def initialize(name, options = {})
+        options = options.dup
+        @script_params = read_option! options, 'script_params'
+        @script = read_option! options, 'script'
+        super(name, options)
+      end
+
+      def as_elastic_aggregation
+        {
+          'bucket_selector' => {
+            'buckets_path' => script_params,
+            'script' => script
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/arelastic/aggregations/bucket_sort.rb
+++ b/lib/arelastic/aggregations/bucket_sort.rb
@@ -20,14 +20,14 @@ module Arelastic
       end
 
       def parse_sort
-        if sort.is_a?(Array)
-          sort.map { |item| Arelastic::Sorts::Field.new(item).as_elastic }
-        elsif sort.is_a?(Hash)
-          sort.map do |bucket_path, order|
-            Arelastic::Sorts::Field.new({ bucket_path => order }).as_elastic
-          end
+        if sort.is_a?(Hash)
+          sort.map { |bucket_path, order| { bucket_path => order } }
         elsif sort.is_a?(String)
-          Arelastic::Sorts::Field.new(sort).as_elastic
+          [sort]
+        elsif sort.is_a?(Array)
+          sort
+        else
+          raise TypeError.new('Expecting a hash, string, or array as the "sort" argument')
         end
       end
     end

--- a/lib/arelastic/aggregations/bucket_sort.rb
+++ b/lib/arelastic/aggregations/bucket_sort.rb
@@ -19,17 +19,19 @@ module Arelastic
         { 'bucket_sort' => bucket_sort }
       end
 
-      def parse_sort
-        if sort.is_a?(Hash)
-          sort.map { |bucket_path, order| { bucket_path => order } }
-        elsif sort.is_a?(String)
-          [sort]
-        elsif sort.is_a?(Array)
-          sort
-        else
-          raise TypeError.new('Expecting a hash, string, or array as the "sort" argument')
+      private
+
+        def parse_sort
+          if sort.is_a?(Hash)
+            sort.map { |bucket_path, order| { bucket_path => order } }
+          elsif sort.is_a?(String)
+            [sort]
+          elsif sort.is_a?(Array)
+            sort
+          else
+            raise TypeError.new('Expecting a hash, string, or array as the "sort" argument')
+          end
         end
-      end
     end
   end
 end

--- a/lib/arelastic/aggregations/bucket_sort.rb
+++ b/lib/arelastic/aggregations/bucket_sort.rb
@@ -1,0 +1,35 @@
+module Arelastic
+  module Aggregations
+    class BucketSort < Arelastic::Aggregations::Aggregation
+      attr_accessor :from, :size, :sort
+
+      def initialize(name, options = {})
+        options = options.dup
+        @from = read_option! options, 'from'
+        @size = read_option! options, 'size'
+        @sort = read_option! options, 'sort'
+        super(name, options)
+      end
+
+      def as_elastic_aggregation
+        bucket_sort = {}
+        bucket_sort['sort'] = parse_sort if sort
+        bucket_sort['from'] = from if from
+        bucket_sort['size'] = size if size
+        { 'bucket_sort' => bucket_sort }
+      end
+
+      def parse_sort
+        if sort.is_a?(Array)
+          sort.map { |item| Arelastic::Sorts::Field.new(item).as_elastic }
+        elsif sort.is_a?(Hash)
+          sort.map do |bucket_path, order|
+            Arelastic::Sorts::Field.new({ bucket_path => order }).as_elastic
+          end
+        elsif sort.is_a?(String)
+          Arelastic::Sorts::Field.new(sort).as_elastic
+        end
+      end
+    end
+  end
+end

--- a/test/arelastic/aggregations/bucket_selector_test.rb
+++ b/test/arelastic/aggregations/bucket_selector_test.rb
@@ -1,0 +1,25 @@
+require 'helper'
+
+class Arelastic::Aggregations::BucketSelectorTest < Minitest::Test
+  def test_as_elastic
+    aggregation = Arelastic::Aggregations::BucketSelector.new('foo_agg',
+      script_params: {
+        'foo_bucket' => 'foo_bucket_path',
+        'bar_bucket' => 'bar_bucket_path'
+      },
+      script: "params.foo_bucket > 10 && params.bar_bucket < 100"
+    )
+    expected = {
+      'foo_agg' => {
+        'bucket_selector' => {
+          'buckets_path' => {
+            'foo_bucket' => 'foo_bucket_path',
+            'bar_bucket' => 'bar_bucket_path'
+          },
+          'script' => 'params.foo_bucket > 10 && params.bar_bucket < 100'
+        }
+      }
+    }
+    assert_equal expected, aggregation.as_elastic
+  end
+end

--- a/test/arelastic/aggregations/bucket_sort_test.rb
+++ b/test/arelastic/aggregations/bucket_sort_test.rb
@@ -20,6 +20,6 @@ class Arelastic::Aggregations::BucketSortTest < Minitest::Test
   end
 
   def parse_sort(sort)
-    Arelastic::Aggregations::BucketSort.new('foosort', sort: sort).parse_sort
+    Arelastic::Aggregations::BucketSort.new('foosort', sort: sort).send(:parse_sort)
   end
 end

--- a/test/arelastic/aggregations/bucket_sort_test.rb
+++ b/test/arelastic/aggregations/bucket_sort_test.rb
@@ -1,0 +1,40 @@
+require 'helper'
+
+class Arelastic::Aggregations::BucketSortTest < Minitest::Test
+  def test_as_elastic
+    with_hash_sort = Arelastic::Aggregations::BucketSort.new('foo_agg', 'size' => 3, 'from' => 5, 'sort' => {
+      'bar_bucket' => 'desc', 'baz_bucket' => 'asc', 'fiz_bucket' => { 'order' => 'asc' }
+    })
+    expected = {
+      'foo_agg' => {
+        'bucket_sort' => {
+          'sort' => [
+            { 'bar_bucket' => 'desc' },
+            { 'baz_bucket' => 'asc' },
+            { 'fiz_bucket' => {'order' => 'asc'} }
+          ],
+          'from' => 5,
+          'size' => 3
+        }
+      }
+    }
+    assert_equal expected, with_hash_sort.as_elastic
+
+    with_array_sort = Arelastic::Aggregations::BucketSort.new('foo_agg', 'sort' =>
+      ['bar_bucket', {'baz_bucket' => 'desc'}, {'fiz_bucket' => {'order' => 'desc'}}]
+    )
+    expected = {
+      'foo_agg' => {
+        'bucket_sort' => {
+          'sort' => [
+            'bar_bucket',
+            { 'baz_bucket' => 'desc' },
+            { 'fiz_bucket' => {'order' => 'desc'} }
+          ]
+
+        }
+      }
+    }
+    assert_equal expected, with_array_sort.as_elastic
+  end
+end

--- a/test/arelastic/aggregations/bucket_sort_test.rb
+++ b/test/arelastic/aggregations/bucket_sort_test.rb
@@ -1,40 +1,26 @@
 require 'helper'
 
 class Arelastic::Aggregations::BucketSortTest < Minitest::Test
-  def test_as_elastic
-    with_hash_sort = Arelastic::Aggregations::BucketSort.new('foo_agg', 'size' => 3, 'from' => 5, 'sort' => {
-      'bar_bucket' => 'desc', 'baz_bucket' => 'asc', 'fiz_bucket' => { 'order' => 'asc' }
-    })
+  def test_parse_sort
+    assert_equal ['foo'], parse_sort('foo')
+    assert_equal [{'foo' => 'desc'}], parse_sort({'foo' => 'desc'})
+    assert_equal [{'foo' => { 'order' => 'desc' }}, 'bar'], parse_sort([{'foo' => { 'order' => 'desc'}}, 'bar'])
+  end
+
+  def test_size_and_from
+    aggregation = Arelastic::Aggregations::BucketSort.new('foo_agg', 'size' => 3, 'from' => 5)
     expected = {
       'foo_agg' => {
         'bucket_sort' => {
-          'sort' => [
-            { 'bar_bucket' => 'desc' },
-            { 'baz_bucket' => 'asc' },
-            { 'fiz_bucket' => {'order' => 'asc'} }
-          ],
           'from' => 5,
           'size' => 3
         }
       }
     }
-    assert_equal expected, with_hash_sort.as_elastic
+    assert_equal expected, aggregation.as_elastic
+  end
 
-    with_array_sort = Arelastic::Aggregations::BucketSort.new('foo_agg', 'sort' =>
-      ['bar_bucket', {'baz_bucket' => 'desc'}, {'fiz_bucket' => {'order' => 'desc'}}]
-    )
-    expected = {
-      'foo_agg' => {
-        'bucket_sort' => {
-          'sort' => [
-            'bar_bucket',
-            { 'baz_bucket' => 'desc' },
-            { 'fiz_bucket' => {'order' => 'desc'} }
-          ]
-
-        }
-      }
-    }
-    assert_equal expected, with_array_sort.as_elastic
+  def parse_sort(sort)
+    Arelastic::Aggregations::BucketSort.new('foosort', sort: sort).parse_sort
   end
 end

--- a/test/arelastic/aggregations/bucket_sort_test.rb
+++ b/test/arelastic/aggregations/bucket_sort_test.rb
@@ -20,6 +20,6 @@ class Arelastic::Aggregations::BucketSortTest < Minitest::Test
   end
 
   def parse_sort(sort)
-    Arelastic::Aggregations::BucketSort.new('foosort', sort: sort).send(:parse_sort)
+    Arelastic::Aggregations::BucketSort.new('foosort', sort: sort).as_elastic['foosort']['bucket_sort']['sort']
   end
 end

--- a/test/arelastic/aggregations/bucket_sort_test.rb
+++ b/test/arelastic/aggregations/bucket_sort_test.rb
@@ -3,8 +3,7 @@ require 'helper'
 class Arelastic::Aggregations::BucketSortTest < Minitest::Test
   def test_parse_sort
     assert_equal ['foo'], parse_sort('foo')
-    assert_equal [{'foo' => 'desc'}], parse_sort({'foo' => 'desc'})
-    assert_equal [{'foo' => { 'order' => 'desc' }}, 'bar'], parse_sort([{'foo' => { 'order' => 'desc'}}, 'bar'])
+    assert_equal [{'foo' => 'desc'}, {'bar' => 'asc'}], parse_sort({'foo' => 'desc', 'bar' => 'asc'})
   end
 
   def test_size_and_from


### PR DESCRIPTION
bucket_sort docs: https://www.elastic.co/guide/en/elasticsearch/reference/7.12/search-aggregations-pipeline-bucket-sort-aggregation.html
bucket_selector docs: https://www.elastic.co/guide/en/elasticsearch/reference/7.12/search-aggregations-pipeline-bucket-selector-aggregation.html