### PR TITLE
Update to v.3.3.2

### DIFF
--- a/arelastic.gemspec
+++ b/arelastic.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'arelastic'
-  s.version = '3.3.0'
+  s.version = '3.3.2'
   s.summary = 'Elastic Search query builder'
   s.description = 'Build Elastic Search queries with objects'
 


### PR DESCRIPTION
I accidentally released `v3.3.1` on RubyGems without bumping the version number specified in the gemspec. So, let's skip `3.3.1` and just release `3.3.2`, with the version in Gemspec matching the one in RubyGems.